### PR TITLE
use fsnotify.v0

### DIFF
--- a/sources/file/main.go
+++ b/sources/file/main.go
@@ -1,15 +1,16 @@
 package file
 
 import (
-	"code.google.com/p/go.exp/fsnotify"
 	"encoding/csv"
 	"errors"
-	"github.com/3onyc/hipdate/shared"
-	"github.com/3onyc/hipdate/sources"
 	"log"
 	"os"
 	"path"
 	"sync"
+
+	"github.com/3onyc/hipdate/shared"
+	"github.com/3onyc/hipdate/sources"
+	"gopkg.in/fsnotify.v0"
 )
 
 var (


### PR DESCRIPTION
fsnotify is currently being maintained at:
https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.
